### PR TITLE
Add interface association descriptor to work on windows

### DIFF
--- a/src/cdc_acm.rs
+++ b/src/cdc_acm.rs
@@ -10,6 +10,7 @@ const USB_CLASS_CDC_DATA: u8 = 0x0a;
 const CDC_SUBCLASS_ACM: u8 = 0x02;
 const CDC_PROTOCOL_NONE: u8 = 0x00;
 
+const CS_INTERFACE_ASSOCIATION: u8 = 0x0B;
 const CS_INTERFACE: u8 = 0x24;
 const CDC_TYPE_HEADER: u8 = 0x00;
 const CDC_TYPE_CALL_MANAGEMENT: u8 = 0x01;
@@ -109,6 +110,19 @@ impl<B: UsbBus> CdcAcmClass<'_, B> {
 
 impl<B: UsbBus> UsbClass<B> for CdcAcmClass<'_, B> {
     fn get_configuration_descriptors(&self, writer: &mut DescriptorWriter) -> Result<()> {
+
+        // Windows will not work with a serial-port without an interface association descriptor.
+        writer.write(
+            CS_INTERFACE_ASSOCIATION,
+            &[
+                self.comm_if,   // first interface
+                2,              // number of interfaces
+                USB_CLASS_CDC,
+                CDC_SUBCLASS_ACM,
+                CDC_PROTOCOL_NONE,
+                0x00            // iFunction None
+            ])?;
+
         writer.interface(
             self.comm_if,
             USB_CLASS_CDC,


### PR DESCRIPTION
I've tested this works on windows after adding the IAD.  I ran into the same problem with [solo](https://github.com/solokeys/solo/blob/master/targets/stm32l432/lib/usbd/usbd_composite.c#L119) not working on windows until it was was.