### PR TITLE
Optionally write interface association descriptor to support composite (CDC + something else) devices on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ repository = "https://github.com/mvirkkunen/usbd-serial"
 embedded-hal = "0.2.2"
 nb = "0.1.2"
 usb-device = "0.2.1"
+
+[patch.crates-io]
+usb-device = { git = "https://github.com/atykhyy/usb-device", rev = "ff5f9c7def93c5975ec5001f7b383fd427b6d0d6" }

--- a/src/cdc_acm.rs
+++ b/src/cdc_acm.rs
@@ -109,6 +109,13 @@ impl<B: UsbBus> CdcAcmClass<'_, B> {
 
 impl<B: UsbBus> UsbClass<B> for CdcAcmClass<'_, B> {
     fn get_configuration_descriptors(&self, writer: &mut DescriptorWriter) -> Result<()> {
+        writer.iad(
+            self.comm_if,
+            2,
+            USB_CLASS_CDC,
+            CDC_SUBCLASS_ACM,
+            CDC_PROTOCOL_NONE)?;
+
         writer.interface(
             self.comm_if,
             USB_CLASS_CDC,


### PR DESCRIPTION
This PR uses the minimal IAD support added by https://github.com/mvirkkunen/usb-device/pull/42 to enable `usbd_serial::CdcAcmClass` / `usbd_serial::SerialPort` added as parts of a composite device to enumerate and function on Windows out-of-the-box, without having to install any drivers or write INF files.

PS: the override for usbd_serial crate in Cargo.toml was added only to enable compilation. Please replace it with an updated version number in dependencies section when merging.