### PR TITLE
update nb dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/usbd-serial"
 
 [dependencies]
-embedded-hal = "0.2.2"
-nb = "0.1.2"
+embedded-hal = "0.2.4"
+nb = "1"
 usb-device = "0.2.7"


### PR DESCRIPTION
The old nb package is a bit tricky to compile with since the same version of nb needs to be used across dependencies.  I suppose the latest nb "1" solves this and `embedded-hal` 2.4 uses it.