### PR TITLE
implement core::fmt::Write

### DIFF
--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -277,7 +277,7 @@ where
     WS: BorrowMut<[u8]>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        match <SerialPort<'_, B, RS, WS>>::write(self, s.as_bytes()) {
+        match self.write(s.as_bytes()) {
             Ok(0) | Err(UsbError::WouldBlock) => Err(fmt::Error),
             Ok(_) => Ok(()),
             Err(_err) => Err(fmt::Error),

--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -1,4 +1,5 @@
 use core::borrow::BorrowMut;
+use core::fmt;
 use core::mem;
 use core::slice;
 use usb_device::class_prelude::*;
@@ -265,6 +266,21 @@ where
             Ok(0) | Err(UsbError::WouldBlock) => Err(nb::Error::WouldBlock),
             Ok(_) => Ok(buf),
             Err(err) => Err(nb::Error::Other(err)),
+        }
+    }
+}
+
+impl<B, RS, WS> fmt::Write for SerialPort<'_, B, RS, WS>
+where
+    B: UsbBus,
+    RS: BorrowMut<[u8]>,
+    WS: BorrowMut<[u8]>,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        match <SerialPort<'_, B, RS, WS>>::write(self, s.as_bytes()) {
+            Ok(0) | Err(UsbError::WouldBlock) => Err(fmt::Error),
+            Ok(_) => Ok(()),
+            Err(_err) => Err(fmt::Error),
         }
     }
 }

--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -277,8 +277,8 @@ where
     WS: BorrowMut<[u8]>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        match self.write(s.as_bytes()) {
-            Ok(0) | Err(UsbError::WouldBlock) => Err(fmt::Error),
+        match <SerialPort<'_, B, RS, WS>>::write(self, s.as_bytes()) {
+            Ok(0) | Err(UsbError::WouldBlock) => Ok(()),
             Ok(_) => Ok(()),
             Err(_err) => Err(fmt::Error),
         }


### PR DESCRIPTION
Implements the [core::fmt::Write](https://doc.rust-lang.org/core/fmt/trait.Write.html) trait to enable things like`serial.write_fmt(format_args!("{}\r\n", val));` (see working example [here](https://github.com/TDHolmes/atsamd/blob/8efa8759af1d704a84afe52ff66ff035278d6127/boards/feather_m0/examples/usb_echo.rs#L80))