### PR TITLE
add build & clippy CI for PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup
+      run: rustup component add clippy
+    - name: Build (default features)
+      run: cargo build --verbose
+    - uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-features


### PR DESCRIPTION
Adds basic build sanity check CI as well as running clippy on new PRs. You can see what this CI looks like on [this PR]( https://github.com/TDHolmes/usbd-serial/pull/1) on my fork. You won't see the CI here until this is merged unfortunately.