### PR TITLE
fixed typo for parity type

### DIFF
--- a/src/cdc_acm.rs
+++ b/src/cdc_acm.rs
@@ -262,7 +262,7 @@ impl From<u8> for StopBits {
 pub enum ParityType {
     None = 0,
     Odd = 1,
-    Event = 2,
+    Even = 2,
     Mark = 3,
     Space = 4,
 }


### PR DESCRIPTION
I think there was a minor typo in the parity type enum, i fixed it. 

This should technically require a major bump but i'm not sure many people have used it according to my github research...

best regards