### PR TITLE
support naming the CDC subinterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-...
+### Added
+- Support assigning interface name strings to the control and data interfaces
 
 ## [0.1.1] - 2020-10-03
 


### PR DESCRIPTION
Hello!

If you're making a composite device with multiple CDC/SerialPort interfaces it's often useful to label them to be able to determine which serial port on the host machine corresponds to which interface.

This PR lets you specify name strings for the control and data interfaces that the host can query.