### PR TITLE
Releasing v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support assigning interface name strings to the control and data interfaces
 - Changed default baud rate from 8000 bps to 9600 bps
 
+### Fixed
+- [breaking] `Parity::Event` was fixed to `Parity::Even`
+
 ## [0.1.1] - 2020-10-03
 
 ## 0.1.0 - 2019-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support assigning interface name strings to the control and data interfaces
 - Changed default baud rate from 8000 bps to 9600 bps
 
+### Changed
+- `usb-device` version bumped to 0.3.0
+
 ### Fixed
 - [breaking] `Parity::Event` was fixed to `Parity::Even`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usbd-serial"
 description = "USB CDC-ACM serial port class for use with usb-device."
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 readme = "README.md"
 keywords = ["no-std", "usb-device"]


### PR DESCRIPTION
This PR releases usbd-serial 0.2, which primarily adds support for the usb-device 0.3.0 crate