### PR TITLE
Fixing embedded-io issue, must poll endpoint before checking read buffer

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -42,6 +42,7 @@ impl<Bus: UsbBus> embedded_io::Read for SerialPort<'_, Bus> {
 
 impl<Bus: UsbBus> embedded_io::ReadReady for SerialPort<'_, Bus> {
     fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        self.poll()?;
         Ok(self.read_buf.available_read() != 0)
     }
 }


### PR DESCRIPTION
For the `read_ready()` function, we need to actually poll the USB endpoint and move data into the buffer before checking if there's data in the buffer.