### PR TITLE
Feature/endpoint accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Added the following `embedded-io` traits to the `SerialPort` object: `Write`, `WriteReady`,
   `Read`, and `ReadReady`, and `ErrorType`
+* The `CdcAcmClass` now exposes the IN and OUT endpoints for direct access via the `read_ep{_mut}`
+  and `write_ep{_mut}` functions.
 
 ## [0.2.0] - 2023-11-13
 

--- a/src/cdc_acm.rs
+++ b/src/cdc_acm.rs
@@ -124,14 +124,24 @@ impl<'a, B: UsbBus> CdcAcmClass<'a, B> {
         self.read_ep.read(data)
     }
 
-    /// Gets the address of the IN endpoint.
-    pub fn write_ep_address(&self) -> EndpointAddress {
-        self.write_ep.address()
+    /// Gets the IN endpoint.
+    pub fn write_ep(&self) -> &EndpointIn<'a, B> {
+        &self.write_ep
     }
 
-    /// Gets the address of the OUT endpoint.
-    pub fn read_ep_address(&self) -> EndpointAddress {
-        self.read_ep.address()
+    /// Mutably gets the IN endpoint.
+    pub fn write_ep_mut(&mut self) -> &mut EndpointIn<'a, B> {
+        &mut self.write_ep
+    }
+
+    /// Gets the OUT endpoint.
+    pub fn read_ep(&self) -> &EndpointOut<'a, B> {
+        &self.read_ep
+    }
+
+    /// Mutably gets the OUT endpoint.
+    pub fn read_ep_mut(&mut self) -> &mut EndpointOut<'a, B> {
+        &mut self.read_ep
     }
 }
 

--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -256,7 +256,7 @@ where
     }
 
     fn endpoint_in_complete(&mut self, addr: EndpointAddress) {
-        if addr == self.inner.write_ep_address() {
+        if addr == self.inner.write_ep().address() {
             self.flush().ok();
         }
     }


### PR DESCRIPTION
This PR updates #19 by making the IN and OUT endpoints of the CdcAcm class publically accessible via accessor functions.

This closes #19 
This closes #21


CC @ianrrees, @thalesfragoso, and @mvirkkunen who were commenting on the initial pull request