### PR TITLE
Preparing for a 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-03-04
+
 ### Added
 * Added the following `embedded-io` traits to the `SerialPort` object: `Write`, `WriteReady`,
   `Read`, and `ReadReady`, and `ErrorType`
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 This is the initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.1...HEAD
+[0.2.0]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.0...v0.2.0
 [0.2.0]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.2.1] - 2024-03-04
+## [0.2.1] - 2024-03-06
 
 ### Added
 * Added the following `embedded-io` traits to the `SerialPort` object: `Write`, `WriteReady`,
@@ -34,6 +34,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 This is the initial release to crates.io.
 
 [Unreleased]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.1...HEAD
-[0.2.1]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.0...v0.2.0
-[0.2.0]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.1.1...v0.2.0
+[0.2.0]: https://github.com/rust-embedded-community/usbd-serial/releases/tag/v0.2.1
+[0.2.0]: https://github.com/rust-embedded-community/usbd-serial/releases/tag/v0.2.0
 [0.1.1]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 This is the initial release to crates.io.
 
 [Unreleased]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.1...HEAD
-[0.2.0]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.0...v0.2.0
+[0.2.1]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.2.0...v0.2.0
 [0.2.0]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/rust-embedded-community/usbd-serial/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usbd-serial"
 description = "USB CDC-ACM serial port class for use with usb-device."
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 readme = "README.md"
 keywords = ["no-std", "usb-device"]


### PR DESCRIPTION
Prepares for a 0.2.1 release.

We can wait until https://github.com/rust-embedded-community/usbd-serial/pull/43 has landed as well.