### PR TITLE
Fixing embedded-io trait implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+* Fixed an issue where the `embedded-io` traits were not implemented if custom buffers were used.
+
 ## [0.2.1] - 2024-03-06
 
 ### Added


### PR DESCRIPTION
Fixes #46 by implementing the `embedded-io` traits for the non-default generic arguments for the serial port, which allows the traits to be implemented for custom buffer types.