### PR TITLE
Fix documentation to match usb-device 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ follows:
 let mut serial = SerialPort::new(&usb_bus);
 
 let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
-    .product("Serial port")
+    .strings(&[StringDescriptors::new(LangID::EN).product("Serial port")])
+    .expect("Failed to set strings")
     .device_class(USB_CLASS_CDC)
     .build();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! CDC-ACM USB serial port implementation for [usb-device](https://crates.io/crates/usb-device).
 //!
 //! CDC-ACM is a USB class that's supported out of the box by most operating systems and used for
-//! implementing modems and generic serial ports. The [`SerialPort`](crate::SerialPort) class
+//! implementing modems and generic serial ports. The [`SerialPort`] class
 //! implements a stream-like buffered serial port that can be used similarly to a normal UART.
 //!
-//! The crate also contains [`CdcAcmClass`](CdcAcmClass) which is a lower-level implementation that
+//! The crate also contains [`CdcAcmClass`] which is a lower-level implementation that
 //! has less overhead, but requires more care to use correctly.
 //!
 //! Example
@@ -13,11 +13,17 @@
 //! A full example requires the use of a hardware-driver, but the hardware independent part is as
 //! follows:
 //!
-//! ```
+//! ```no_run
+//! # use usb_device::class_prelude::*;
+//! # fn dummy(usb_bus: UsbBusAllocator<impl UsbBus>) {
+//! use usb_device::prelude::*;
+//! use usbd_serial::{SerialPort, USB_CLASS_CDC};
+//!
 //! let mut serial = SerialPort::new(&usb_bus);
 //!
 //! let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
-//!     .product("Serial port")
+//!     .strings(&[StringDescriptors::new(LangID::EN).product("Serial port")])
+//!     .expect("Failed to set strings")
 //!     .device_class(USB_CLASS_CDC)
 //!     .build();
 //!
@@ -32,18 +38,19 @@
 //!         Ok(count) => {
 //!             // count bytes were read to &buf[..count]
 //!         },
-//!         Err(UsbError::WouldBlock) => // No data received
-//!         Err(err) => // An error occurred
+//!         Err(UsbError::WouldBlock) => { /* No data received */ },
+//!         Err(err) => { /* An error occurred */ },
 //!     };
 //!
 //!     match serial.write(&[0x3a, 0x29]) {
 //!         Ok(count) => {
 //!             // count bytes were written
 //!         },
-//!         Err(UsbError::WouldBlock) => // No data could be written (buffers full)
-//!         Err(err) => // An error occurred
+//!         Err(UsbError::WouldBlock) => { /* No data could be written (buffers full) */ },
+//!         Err(err) => { /* An error occurred */ },
 //!     };
 //! }
+//! # }
 //! ```
 
 #![no_std]


### PR DESCRIPTION
`UsbDeviceBuilder` has changed slightly, this updates the documentation accordingly. Also it's now possible to run tests:

```
% cargo test              
   Compiling usbd-serial v0.2.2 (/redacted/usbd-serial)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.29s
     Running unittests src/lib.rs (target/debug/deps/usbd_serial-8f07a6ca69583646)

running 4 tests
test buffer::tests::clear ... ok
test buffer::tests::discard ... ok
test buffer::tests::read ... ok
test buffer::tests::write ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests usbd_serial

running 1 test
test src/lib.rs - (line 16) - compile ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```